### PR TITLE
Switch to using `build_dependencies`

### DIFF
--- a/rockspec_template.txt
+++ b/rockspec_template.txt
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.4-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.5-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.5-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.6-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.6-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.14.7-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.14.7-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.10-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.10-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.11-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.11-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.12-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.12-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.13-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.13-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.14-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.14-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.4-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.5-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.5-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.6-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.6-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.7-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.7-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.8-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.8-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.15.9-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.15.9-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.4-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.5-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.5-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.6-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.6-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.7-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.7-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.8-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.8-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.16.9-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.16.9-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.17.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.17.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.17.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.17.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.17.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.17.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.17.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.17.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.18.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.18.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.18.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.18.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.18.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.18.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.18.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.18.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.19.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.19.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.19.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.19.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.19.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.19.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.19.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.19.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.19.4-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.19.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.19.5-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.19.5-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.4-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.5-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.5-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.6-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.6-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.7-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.7-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.8-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.8-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.20.9-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.20.9-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.21.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.21.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.22.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.22.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.22.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.22.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.22.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.22.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.22.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.22.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.22.4-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.22.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.22.5-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.22.5-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.22.6-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.22.6-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.23.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.23.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.23.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.23.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.23.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.23.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.2-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.2-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.3-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.3-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.4-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.4-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.5-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.5-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.6-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.6-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.24.7-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.24.7-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.25.0-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.25.0-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/rockspecs/tree-sitter-cli-0.25.1-1.rockspec
+++ b/rockspecs/tree-sitter-cli-0.25.1-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 

--- a/tree-sitter-cli-scm-1.rockspec
+++ b/tree-sitter-cli-scm-1.rockspec
@@ -17,7 +17,7 @@ description = {
 
 supported_platforms = {"linux", "macosx", "windows"}
 
-dependencies = {
+build_dependencies = {
    "luarocks-build-tree-sitter-cli==0.0.2",
 }
 


### PR DESCRIPTION
When working on creating a `luarocks.lock` file for teal-language-server, I noticed that `luarocks-build-tree-sitter-cli` was showing up as a dependency and not a build dependency, which was causing some issues when installing (in this CI run for example: https://github.com/teal-language/teal-language-server/actions/runs/13233684216/job/36934823379)

This should fix the issue.